### PR TITLE
Fix optional storageClassName in PVC

### DIFF
--- a/helm/templates/pvc.yaml
+++ b/helm/templates/pvc.yaml
@@ -20,7 +20,9 @@ metadata:
 spec:
   accessModes:
   - ReadWriteMany
+  {{- if .Values.persistence.storageClass }}
   storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.persistence.size | default "10G" | quote }}


### PR DESCRIPTION
## Summary
- conditionally include `storageClassName` in PVC template

## Testing
- `helm lint` *(fails: helm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f98ecaca0832489aeeb61cfb9d75b