### PR TITLE
Update Docker base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-apache
+FROM php:8.3-apache
 
 LABEL vendor="Mautic"
 


### PR DESCRIPTION
## Summary
- upgrade PHP base image to 8.3 in Dockerfile

## Testing
- `docker build -t omnis-mautic-test ./docker` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684357ae1db48324b306354c12589bd3