### PR TITLE
Fix Dockerfile clone

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,8 +69,10 @@ WORKDIR /var/www/html
 RUN echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
 
 USER www-data
-# Clone Mautic Git repository
-RUN git clone https://github.com/mautic/mautic.git /var/www/html
+# Clone Mautic Git repository and checkout the configured version
+RUN git clone https://github.com/mautic/mautic.git /var/www/html \
+    && cd /var/www/html \
+    && git checkout tags/${MAUTIC_VERSION}
 
 WORKDIR /var/www/html
 RUN composer update && composer install


### PR DESCRIPTION
## Summary
- ensure the Docker build checks out the configured Mautic version before running composer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876783510c48324bf7bf4f3e583c8cf