### PR TITLE
Add PVC retention toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ redis:
 ## RabbitMQ password secret
 
 This chart automatically creates a secret containing the RabbitMQ password. The secret name is controlled by `rabbitmq.auth.existingPasswordSecret` and defaults to `mautic-rabbitmq-password`.
+
+## PVC cleanup on uninstall
+
+PersistentVolumeClaims created for Mautic's data will be deleted when the Helm release is removed unless you opt into retaining them. Set `persistence.retain` to `true` in your values file if you want to keep the PVC around after running `helm uninstall`:
+
+```yaml
+persistence:
+  retain: true
+```

--- a/helm/templates/pvc.yaml
+++ b/helm/templates/pvc.yaml
@@ -8,15 +8,16 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.persistence.annotations .Values.commonAnnotations }}
   annotations:
+    {{- if .Values.persistence.retain }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     {{- if .Values.persistence.annotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.persistence.annotations "context" $ ) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- end }}
 spec:
   accessModes:
   - ReadWriteOnce

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -147,6 +147,7 @@ configs:
 persistence:
   enabled: true
   storageClass: ""
+  retain: false
   size: 10Gi
 
 trustedIPs: ["0.0.0.0/0"]


### PR DESCRIPTION
## Summary
- enable optional PVC retention via `persistence.retain` value
- document how to keep or delete Mautic's PVCs on uninstall

## Testing
- `helm lint helm` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687887a447bc83248cd7895620bd7a21